### PR TITLE
Removed CSS that stops hiding edit icons and disables other popups

### DIFF
--- a/react-app/src/pages/ClassPage/ClassMain/ClassMain.module.css
+++ b/react-app/src/pages/ClassPage/ClassMain/ClassMain.module.css
@@ -49,8 +49,6 @@
 
 .icon {
   width: 25px;
-  filter: brightness(0) saturate(100%) invert(68%) sepia(6%) saturate(0%)
-    hue-rotate(192deg) brightness(89%) contrast(97%);
 }
 
 .icon:hover {

--- a/react-app/src/pages/SettingsPage/SettingsPage.module.css
+++ b/react-app/src/pages/SettingsPage/SettingsPage.module.css
@@ -80,8 +80,6 @@
 
 .editIcon {
   width: 25px;
-  filter: brightness(0) saturate(100%) invert(68%) sepia(6%) saturate(0%)
-    hue-rotate(192deg) brightness(89%) contrast(97%);
 }
 
 .editIcon:hover {


### PR DESCRIPTION
Just removed this styling from the edit icons:
```
filter: brightness(0) saturate(100%) invert(68%) sepia(6%) saturate(0%)
    hue-rotate(192deg) brightness(89%) contrast(97%);
```