### PR TITLE
38 roster delete popup

### DIFF
--- a/react-app/src/pages/StudentRosterPage/StudentList/DeleteStudentConfirmation/DeleteStudentConfirmation.module.css
+++ b/react-app/src/pages/StudentRosterPage/StudentList/DeleteStudentConfirmation/DeleteStudentConfirmation.module.css
@@ -17,6 +17,32 @@
   cursor: pointer;
 }
 
+.title {
+  margin: 0;
+  padding: 0;
+  font-size: 27px;
+  width: 300px;
+  text-align: center;
+}
+
+.titleContent {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: black;
+}
+
+.error {
+  text-align: center;
+  height: 25px;
+  margin: 10px 0 0 0;
+  padding: 0;
+  font-size: 0.8rem;
+  color: red;
+}
+
 .content {
   width: 100%;
   display: flex;
@@ -27,17 +53,9 @@
 }
 
 .content p {
+  margin-top: 0px;
   margin-bottom: 30px;
-  margin-top: 30px;
   width: 75%;
-  text-align: center;
-}
-
-.title {
-  margin: 0;
-  padding: 0;
-  font-size: 27px;
-  width: 300px;
   text-align: center;
 }
 
@@ -80,6 +98,7 @@
 }
 
 .actionsContainer button:hover {
+  color: white;
   cursor: pointer;
   background: var(--color-orange);
 }

--- a/react-app/src/pages/StudentRosterPage/StudentList/DeleteStudentConfirmation/DeleteStudentConfirmation.tsx
+++ b/react-app/src/pages/StudentRosterPage/StudentList/DeleteStudentConfirmation/DeleteStudentConfirmation.tsx
@@ -16,7 +16,6 @@ interface popupModalType {
   setStudents: Function;
   reloadList: Boolean;
   setOpenSuccess: Function;
-  setOpenFailure: Function;
 }
 
 const DeleteStudentConfirmation = ({
@@ -30,9 +29,8 @@ const DeleteStudentConfirmation = ({
   students,
   reloadList,
   setOpenSuccess,
-  setOpenFailure,
 }: popupModalType): React.ReactElement => {
-  const [submittedError, setSubmittedError] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   function handleConfirm() {
     if (removeStudentId != 'undefined') {
@@ -44,81 +42,73 @@ const DeleteStudentConfirmation = ({
             }),
           );
           setReloadList(true);
+          onClose();
           setOpenSuccess(true);
         })
         .catch((err) => {
-          setOpenFailure(true);
+          setErrorMessage('*Student could not be Removed');
         });
     }
-    onClose();
   }
 
   const handleOnClose = (): void => {
-    setSubmittedError(false);
     onClose();
   };
 
   return (
     <Modal
-      height={260}
+      height={270}
       open={open}
       onClose={(e: React.MouseEvent<HTMLButtonElement>) => {
         handleOnClose();
       }}
     >
-      <div>
-        <div className={styles.header}>
-          <button
-            type="button"
-            className={styles.close}
-            onClick={() => {
-              handleOnClose();
-            }}
-          >
-            <img src={x} alt="Close popup" />
-          </button>
-        </div>
-        <div className={styles.content}>
-          <h2 className={styles.title}>Remove Student Confirmation</h2>
-          <p>
-            {submittedError ? (
-              'Log out failed. Try again later.'
-            ) : (
-              <div className={styles.bodyText}>
-                Are you sure you would like to remove?
-                <div className={styles.name}>
-                  {popupName === 'undefined' ? '' : popupName}
-                </div>
-                <div className={styles.email}>
-                  {popupEmail === 'undefined' ? '' : <>({popupEmail})</>}
-                </div>
-              </div>
-            )}
-          </p>
-        </div>
-        <div className={styles.actions}>
-          <div className={styles.actionsContainer}>
-            {submittedError ? (
-              <></>
-            ) : (
-              <>
-                <button
-                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                    handleConfirm();
-                  }}
-                >
-                  Yes
-                </button>
-                <button
-                  onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-                    handleOnClose();
-                  }}
-                >
-                  No
-                </button>
-              </>
-            )}
+      <div className={styles.header}>
+        <button
+          type="button"
+          className={styles.close}
+          onClick={() => {
+            handleOnClose();
+          }}
+        >
+          <img src={x} alt="Close popup" />
+        </button>
+      </div>
+      <div className={styles.titleContent}>
+        <h2 className={styles.title}>Remove Student Confirmation</h2>
+      </div>
+      <p className={styles.error}>{errorMessage}</p>
+      <div className={styles.content}>
+        <p>
+          <div className={styles.bodyText}>
+            Are you sure you would like to remove?
+            <div className={styles.name}>
+              {popupName === 'undefined' ? '' : popupName}
+            </div>
+            <div className={styles.email}>
+              {popupEmail === 'undefined' ? '' : <>({popupEmail})</>}
+            </div>
           </div>
+        </p>
+      </div>
+      <div className={styles.actions}>
+        <div className={styles.actionsContainer}>
+          <>
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                handleConfirm();
+              }}
+            >
+              Yes
+            </button>
+            <button
+              onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+                handleOnClose();
+              }}
+            >
+              No
+            </button>
+          </>
         </div>
       </div>
     </Modal>

--- a/react-app/src/pages/StudentRosterPage/StudentList/StudentList.tsx
+++ b/react-app/src/pages/StudentRosterPage/StudentList/StudentList.tsx
@@ -12,7 +12,6 @@ const StudentList = (props: {
   students: Array<Partial<StudentID>>;
   setStudents: Function;
   setOpenSuccess: Function;
-  setOpenFailure: Function;
 }) => {
   const [studentList, setStudentList] = useState<any[]>([]);
   const [showPopup, setShowPopup] = useState(false);
@@ -111,7 +110,6 @@ const StudentList = (props: {
               students={props.students}
               setStudents={props.setStudents}
               setOpenSuccess={props.setOpenSuccess}
-              setOpenFailure={props.setOpenFailure}
             />
           )}
           {numToShow < props.students.length && (

--- a/react-app/src/pages/StudentRosterPage/StudentRosterPage.tsx
+++ b/react-app/src/pages/StudentRosterPage/StudentRosterPage.tsx
@@ -17,10 +17,8 @@ const StudentRosterPage = (): JSX.Element => {
 
   //Used to handle Deletion alert
   const [openSuccess, setOpenSuccess] = useState<boolean>(false);
-  const [openFailure, setOpenFailure] = useState<boolean>(false);
   const handleToClose = (event: any, reason: any) => {
     setOpenSuccess(false);
-    setOpenFailure(false);
   };
 
   const auth = useAuth();
@@ -125,7 +123,6 @@ const StudentRosterPage = (): JSX.Element => {
                 students={students}
                 setStudents={setStudents}
                 setOpenSuccess={setOpenSuccess}
-                setOpenFailure={setOpenFailure}
               />
             )}
           </div>
@@ -140,20 +137,6 @@ const StudentRosterPage = (): JSX.Element => {
           >
             <Alert severity="success" sx={{ width: '100%' }}>
               Student was Successfully Removed
-            </Alert>
-          </Snackbar>
-
-          <Snackbar
-            anchorOrigin={{
-              horizontal: 'right',
-              vertical: 'bottom',
-            }}
-            open={openFailure}
-            autoHideDuration={3000}
-            onClose={handleToClose}
-          >
-            <Alert severity="error" sx={{ width: '100%' }}>
-              Student could not be Removed
             </Alert>
           </Snackbar>
         </>

--- a/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.module.css
+++ b/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.module.css
@@ -26,9 +26,18 @@
   color: black;
 }
 
-.content p {
+.error {
+  text-align: center;
+  height: 25px;
+  margin: 10px 0 0 0;
+  padding: 0;
+  font-size: 0.8rem;
+  color: red;
+}
+
+.contentBody {
   margin-bottom: 30px;
-  margin-top: 30px;
+  margin-top: 0px;
   width: 75%;
   text-align: center;
 }
@@ -82,4 +91,5 @@
 .actionsContainer button:hover {
   cursor: pointer;
   background: var(--color-orange);
+  color: white;
 }

--- a/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.tsx
+++ b/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.tsx
@@ -35,6 +35,7 @@ const DeleteTeacherConfirmation = ({
   setOpenFailure,
 }: popupModalType): React.ReactElement => {
   const [submittedError, setSubmittedError] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   function handleConfirm() {
     if (removeTeacherId != 'undefined') {
@@ -49,7 +50,7 @@ const DeleteTeacherConfirmation = ({
           setOpenSuccess(true);
         })
         .catch((err) => {
-          setOpenFailure(true);
+          setErrorMessage('*Teacher could not be removed');
         });
     }
     onClose();
@@ -62,7 +63,7 @@ const DeleteTeacherConfirmation = ({
 
   return (
     <Modal
-      height={260}
+      height={270}
       open={open}
       onClose={(e: React.MouseEvent<HTMLButtonElement>) => {
         handleOnClose();
@@ -82,7 +83,8 @@ const DeleteTeacherConfirmation = ({
         </div>
         <div className={styles.content}>
           <h2 className={styles.title}>Remove Teacher Confirmation</h2>
-          <p>
+          <p className={styles.error}>{errorMessage}</p>
+          <p className={styles.contentBody}>
             {submittedError ? (
               'Log out failed. Try again later.'
             ) : (

--- a/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.tsx
+++ b/react-app/src/pages/TeacherRosterPage/TeacherList/DeleteTeacherConfirmation/DeleteTeacherConfirmation.tsx
@@ -46,6 +46,7 @@ const DeleteTeacherConfirmation = ({
               return teacher.auth_id !== removeTeacherId.valueOf();
             }),
           );
+          onClose();
           setReloadList(true);
           setOpenSuccess(true);
         })
@@ -53,7 +54,6 @@ const DeleteTeacherConfirmation = ({
           setErrorMessage('*Teacher could not be removed');
         });
     }
-    onClose();
   }
 
   const handleOnClose = (): void => {

--- a/react-app/src/pages/TeacherRosterPage/TeacherRosterPage.tsx
+++ b/react-app/src/pages/TeacherRosterPage/TeacherRosterPage.tsx
@@ -149,20 +149,6 @@ const TeacherRosterPage = (): JSX.Element => {
               Teacher was Successfully Removed
             </Alert>
           </Snackbar>
-
-          <Snackbar
-            anchorOrigin={{
-              horizontal: 'right',
-              vertical: 'bottom',
-            }}
-            open={openFailure}
-            autoHideDuration={3000}
-            onClose={handleToClose}
-          >
-            <Alert severity="error" sx={{ width: '100%' }}>
-              Teacher could not be Removed
-            </Alert>
-          </Snackbar>
         </>
       )}
     </>


### PR DESCRIPTION
Removed the snack bar alert that would show when the deletion of a student/teacher within the student/teacher roster page was unsuccessful. Changed it so that the error is now shown within the popup itself, however, the success alert still remains.